### PR TITLE
Use filepath.IsAbs method for absolute-path detection

### DIFF
--- a/realpath.go
+++ b/realpath.go
@@ -18,7 +18,7 @@ func Realpath(fpath string) (string, error) {
 		return "", os.ErrInvalid
 	}
 
-	if fpath[0] != os.PathSeparator {
+	if !filepath.IsAbs(fpath) {
 		pwd, err := os.Getwd()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This makes realpath work on windows. The previous method could not detect the mulit-root nature of the windows filesystem, but Go's filepath package handles this for us.